### PR TITLE
Remove Pexel from TK loot prio since he's DEAD

### DIFF
--- a/TK.json
+++ b/TK.json
@@ -68,7 +68,7 @@
 			"wowID": "29947"
 		},
 		"Mindstorm Wristbands":{
-			"prio":["Demondred(1)", "Pexel(1)", "Killmcpickle(1)", "Coxxy(1)", "Cannie(1)", "Rubski(2)","EP/GP"],
+			"prio":["Demondred(1)", "Killmcpickle(1)", "Coxxy(1)", "Cannie(1)", "Rubski(2)","EP/GP"],
 			"gp":"6",
 			"wowID":"29918"
 		},


### PR DESCRIPTION
Remove Pexel from TK loot prio since he's DEAD